### PR TITLE
Adds null-check around setting sort

### DIFF
--- a/src/main/java/com/lifeinide/jsonql/core/dto/BasePageableRequest.java
+++ b/src/main/java/com/lifeinide/jsonql/core/dto/BasePageableRequest.java
@@ -58,7 +58,9 @@ public class BasePageableRequest<S extends SortField> implements Serializable, P
 	}
 
 	public BasePageableRequest withSort(S sort) {
-		getSort().add(sort);
+		if (sort != null) {
+			getSort().add(sort);
+		}
 		return this;
 	}
 


### PR DESCRIPTION
If the sort object is passed as an optional argument to a GraphQL query, then it can be null.
I would rather not need to check for null everywhere I call the withSort(..) function, it's nicer to have it built into the library.